### PR TITLE
Add argument handling to cli

### DIFF
--- a/pet_cli.py
+++ b/pet_cli.py
@@ -3,11 +3,22 @@ Can be used as a demonstration of the class or
 as a convenient way to test new functionality.
 """
 
+import sys
 from pet import Pet
 
 
 if __name__ == '__main__':
-    p = Pet()
+    args = sys.argv
+    stack = []
+    state_file = None
+    while len(args) > 1:
+        arg = args.pop()
+        if arg == '-f':
+            state_file = stack.pop()
+        else:
+            stack.append(arg)
+
+    p = Pet(state_file)
     print 'Type something to interact or type "quit" to quit.'
 
     while True:


### PR DESCRIPTION
This change makes it possible to add arguments to the command line interface. At this stage, only recognized option is `-f [file name]` for specifying the state file name. For example, use `python pet_cli.py -f state.json` to store the data to the file state.json.

Arguments are parsed in reverse order using a stack machine style code. Any argument not recognized as an option will be considered an operand and pushed on the stack. Option flags work like operators. They pop the expected number of arguments and perform whatever operation they need. Adding more options is easy, just add an `elif` for that option.
